### PR TITLE
Add "--aggregation" arg to convert multiple reports

### DIFF
--- a/ReportConverter/Arguments/ArgAttributes.cs
+++ b/ReportConverter/Arguments/ArgAttributes.cs
@@ -99,4 +99,39 @@ namespace ReportConverter
 
         public string ResourceName { get; set; }
     }
+
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
+    class ArgSampleAttribute : Attribute
+    {
+        private List<string> _sampleLines;
+
+        private ArgSampleAttribute()
+        {
+            _sampleLines = new List<string>();
+        }
+
+        public ArgSampleAttribute(string description) : this()
+        {
+            _sampleLines.Add(description);
+        }
+
+        public ArgSampleAttribute(params string[] descriptionLines) : this()
+        {
+            _sampleLines.AddRange(descriptionLines);
+        }
+
+        public IEnumerable<string> Lines
+        {
+            get
+            {
+                if (_sampleLines.Count == 0 && !string.IsNullOrWhiteSpace(ResourceName))
+                {
+                    _sampleLines.Add(Properties.Resources.ResourceManager.GetString(ResourceName));
+                }
+                return _sampleLines;
+            }
+        }
+
+        public string ResourceName { get; set; }
+    }
 }

--- a/ReportConverter/Arguments/ArgHelper.cs
+++ b/ReportConverter/Arguments/ArgHelper.cs
@@ -37,13 +37,16 @@ namespace ReportConverter
             foreach (PropertyInfo pi in props)
             {
                 ArgDescriptionAttribute argDesc = pi.GetCustomAttribute<ArgDescriptionAttribute>();
+                IEnumerable<ArgSampleAttribute> argSamples = pi.GetCustomAttributes<ArgSampleAttribute>();
+
                 OptionalArgAttribute optArg = pi.GetCustomAttribute<OptionalArgAttribute>();
                 if (optArg != null)
                 {
                     _optArgs.Add(new OptArgInfo(pi, optArg)
                     {
                         Value = pi.GetCustomAttribute<OptionalArgValueAttribute>(),
-                        Description = argDesc
+                        Description = argDesc,
+                        Samples = argSamples
                     });
                     continue;
                 }
@@ -53,7 +56,8 @@ namespace ReportConverter
                 {
                     _posArgs.Add(new PosArgInfo(pi, posArg)
                     {
-                        Description = argDesc
+                        Description = argDesc,
+                        Samples = argSamples
                     });
                     continue;
                 }
@@ -159,6 +163,8 @@ namespace ReportConverter
                 else
                 {
                     // positional argument
+                    cmdArgs.AllPositionalArgs.Add(arg);
+
                     pos++;
                     if (pos < _posArgs.Count)
                     {
@@ -214,6 +220,24 @@ namespace ReportConverter
                             w.WriteLine(indentLv1 + line);
                         }
                         w.WriteLine();
+                    }
+
+                    if (posArg.Samples != null)
+                    {
+                        int i = 0;
+                        foreach (ArgSampleAttribute sample in posArg.Samples)
+                        {
+                            if (sample.Lines.Count() > 0)
+                            {
+                                i++;
+                                w.WriteLine(string.Format(indentLv1 + Properties.Resources.Prog_Usage_SampleTitle, i));
+                                foreach (string line in sample.Lines)
+                                {
+                                    w.WriteLine(indentLv1 + line);
+                                }
+                                w.WriteLine();
+                            }
+                        }
                     }
                 }
                 w.WriteLine();
@@ -278,6 +302,24 @@ namespace ReportConverter
                         }
                         w.WriteLine();
                     }
+
+                    if (optArg.Samples != null)
+                    {
+                        int i = 0;
+                        foreach (ArgSampleAttribute sample in optArg.Samples)
+                        {
+                            if (sample.Lines.Count() > 0)
+                            {
+                                i++;
+                                w.WriteLine(string.Format(indentLv2 + Properties.Resources.Prog_Usage_SampleTitle, i));
+                                foreach (string line in sample.Lines)
+                                {
+                                    w.WriteLine(indentLv2 + line);
+                                }
+                                w.WriteLine();
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -292,6 +334,7 @@ namespace ReportConverter
 
         public PropertyInfo PropertyInfo { get; private set; }
         public ArgDescriptionAttribute Description { get; set; }
+        public IEnumerable<ArgSampleAttribute> Samples { get; set; }
     }
 
     class OptArgInfo : ArgInfo

--- a/ReportConverter/Arguments/CommandArguments.cs
+++ b/ReportConverter/Arguments/CommandArguments.cs
@@ -11,6 +11,8 @@ namespace ReportConverter
     {
         public CommandArguments()
         {
+            AllPositionalArgs = new List<string>();
+
             JUnitXmlFile = string.Empty;
             NUnit3XmlFile = string.Empty;
             ShowVersion = false;
@@ -29,6 +31,11 @@ namespace ReportConverter
         //[ArgDescription("The file path to save the converted report in NUnit 3 XML format.")]
         public string NUnit3XmlFile { get; set; }
 
+        [OptionalArg("aggregation", "a")]
+        [ArgDescription(ResourceName = "ArgDesc_AggregationOption")]
+        [ArgSample("ReportConverter -j \"output.xml\" --aggregation \"report1\" \"report2\"")]
+        public bool Aggregation { get; set; }
+
         [OptionalArg("version", "V")]
         [ArgDescription(ResourceName = "ArgDesc_ShowVersionOption")]
         public bool ShowVersion { get; set; }
@@ -39,8 +46,9 @@ namespace ReportConverter
         #endregion
 
         #region Positional arguments
-        [PositionalArg(1, "<directory>")]
+        [PositionalArg(1, "<directory> [...]")]
         [ArgDescription(ResourceName = "ArgDesc_InputFile")]
+        [ArgSample("ReportConverter -j \"output.xml\" --aggregation \"report1\" \"report2\"")]
         public string InputPath { get; set; }
         #endregion
 
@@ -63,5 +71,7 @@ namespace ReportConverter
                 return of;
             }
         }
+
+        public IList<string> AllPositionalArgs { get; private set; }
     }
 }

--- a/ReportConverter/JUnit/APITestReportConverter.cs
+++ b/ReportConverter/JUnit/APITestReportConverter.cs
@@ -8,6 +8,11 @@ using System.Threading.Tasks;
 
 namespace ReportConverter.JUnit
 {
+    /// <summary>
+    /// Junit-testsuites <==> API test
+    /// Junit-testsuite <==> Iteration
+    /// Junit-testcase <==> Activity
+    /// </summary>
     class APITestReportConverter : ConverterBase
     {
         public APITestReportConverter(CommandArguments args, TestReport input) : base(args)
@@ -93,7 +98,7 @@ namespace ReportConverter.JUnit
             return list.ToArray();
         }
 
-        private testsuiteTestcase[] ConvertTestcases(IterationReport iterationReport, out int count, out int numOfFailures)
+        public static testsuiteTestcase[] ConvertTestcases(IterationReport iterationReport, out int count, out int numOfFailures)
         {
             count = 0;
             numOfFailures = 0;
@@ -102,7 +107,7 @@ namespace ReportConverter.JUnit
             EnumerableReportNodes<ActivityReport> activities = new EnumerableReportNodes<ActivityReport>(iterationReport.AllActivitiesEnumerator);
             foreach (ActivityReport activity in activities)
             {
-                list.Add(ConvertTestcase(activity, count + 1));
+                list.Add(ConvertTestcase(activity, count));
                 if (activity.Status == ReportStatus.Failed)
                 {
                     numOfFailures++;
@@ -113,10 +118,10 @@ namespace ReportConverter.JUnit
             return list.ToArray();
         }
 
-        private testsuiteTestcase ConvertTestcase(ActivityReport activityReport, int index)
+        public static testsuiteTestcase ConvertTestcase(ActivityReport activityReport, int index)
         {
             testsuiteTestcase tc = new testsuiteTestcase();
-            tc.name = string.Format("#{0,5:00000}: {1}", index, activityReport.Name);
+            tc.name = string.Format("#{0,5:00000}: {1}", index + 1, activityReport.Name);
             if (activityReport.ActivityExtensionData != null && activityReport.ActivityExtensionData.VTDType != null)
             {
                 tc.classname = activityReport.ActivityExtensionData.VTDType.Value;

--- a/ReportConverter/JUnit/AggregativeReportConverter.cs
+++ b/ReportConverter/JUnit/AggregativeReportConverter.cs
@@ -1,0 +1,406 @@
+﻿using ReportConverter.XmlReport;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReportConverter.JUnit
+{
+    /// <summary>
+    /// Junit-testsuites <==> aggregative tests
+    /// Junit-testsuite <==> GUI / API / BPT test
+    /// Junit-testcase <==> Step / Activity
+    /// </summary>
+    class AggregativeReportConverter : ConverterBase
+    {
+        public AggregativeReportConverter(CommandArguments args, IEnumerable<TestReportBase> testReports) : base(args)
+        {
+            TestSuites = new testsuites();
+            TestReports = testReports;
+            if (TestReports == null)
+            {
+                TestReports = new List<TestReportBase>(0);
+            }
+        }
+
+        public IEnumerable<TestReportBase> TestReports { get; private set; }
+
+        public testsuites TestSuites { get; private set; }
+
+        public override bool SaveFile()
+        {
+            return SaveFileInternal(TestSuites);
+        }
+
+        public override bool Convert()
+        {
+            List<testsuitesTestsuite> list = new List<testsuitesTestsuite>();
+
+            int index = -1;
+            foreach (TestReportBase testReport in this.TestReports)
+            {
+                index++;
+                list.Add(ConvertTestsuite(testReport, index));
+            }
+
+            TestSuites.testsuite = list.ToArray();
+            return true;
+        }
+
+        private testsuitesTestsuite ConvertTestsuite(TestReportBase testReport, int index)
+        {
+            // GUI test?
+            testsuitesTestsuite ts = TryConvertTestsuite(testReport as XmlReport.GUITest.TestReport, index);
+            if (ts != null)
+            {
+                return ts;
+            }
+
+            // API test?
+            ts = TryConvertTestsuite(testReport as XmlReport.APITest.TestReport, index);
+            if (ts != null)
+            {
+                return ts;
+            }
+
+            // BPT test?
+            ts = TryConvertTestsuite(testReport as XmlReport.BPT.TestReport, index);
+            if (ts != null)
+            {
+                return ts;
+            }
+
+            // none of above, return the default testsuite with only common data, that is, no testcases
+            ts = new testsuitesTestsuite();
+            FillTestsuiteCommonData(ts, testReport, index);
+            return ts;
+        }
+
+        #region For GUI test only
+        // For GUI test only
+        private static testsuitesTestsuite TryConvertTestsuite(XmlReport.GUITest.TestReport testReport, int index)
+        {
+            if (testReport == null)
+            {
+                return null;
+            }
+
+            testsuitesTestsuite ts = new testsuitesTestsuite();
+            FillTestsuiteCommonData(ts, testReport, index);
+
+            // JUnit testcases
+            int testcaseCount = 0;
+            int failureCount = 0;
+            ts.testcase = ConvertTestcases(testReport.AllStepsEnumerator, out testcaseCount, out failureCount);
+            ts.tests = testcaseCount;
+            ts.failures = failureCount;
+
+            return ts;
+        }
+
+        // For GUI test only
+        private static testsuiteTestcase[] ConvertTestcases(ReportNodeEnumerator<XmlReport.GUITest.StepReport> steps, out int count, out int numOfFailures)
+        {
+            count = 0;
+            numOfFailures = 0;
+
+            List<testsuiteTestcase> list = new List<testsuiteTestcase>();
+            if (steps != null)
+            {
+                EnumerableReportNodes<XmlReport.GUITest.StepReport> stepReports = new EnumerableReportNodes<XmlReport.GUITest.StepReport>(steps);
+                foreach (XmlReport.GUITest.StepReport step in stepReports)
+                {
+                    testsuiteTestcase tc = GUITestReportConverter.ConvertTestcase(step, count);
+                    if (tc == null)
+                    {
+                        continue;
+                    }
+
+                    // update step name with the hierarchy full name
+                    tc.name = string.Format("#{0,7:0000000}: {1}", count + 1, GetHierarchyFullName(step));
+
+                    list.Add(tc);
+                    if (step.Status == ReportStatus.Failed)
+                    {
+                        numOfFailures++;
+                    }
+                    count++;
+                }
+            }
+
+            return list.ToArray();
+        }
+
+        // For GUI test only
+        private static string GetHierarchyFullName(XmlReport.GUITest.StepReport stepReport, string split = " / ")
+        {
+            string hierarchyName = stepReport.Name;
+
+            GeneralReportNode parentReport = stepReport.Owner as GeneralReportNode;
+            while (parentReport != null)
+            {
+                string name = parentReport.Name;
+
+                if (parentReport is XmlReport.GUITest.ContextReport)
+                {
+                    parentReport = parentReport.Owner as GeneralReportNode;
+                    continue;
+                }
+                else if (parentReport is XmlReport.GUITest.ActionIterationReport actionIterationReport)
+                {
+                    // if it is GUI action iteration, prepend "Action Iteration" term
+                    name = string.Format("{0} {1}", Properties.Resources.PropName_ActionIteration, actionIterationReport.Index);
+                }
+                else if (parentReport is XmlReport.GUITest.IterationReport iterationReport)
+                {
+                    // if it is GUI iteration, prepend "Iteration" term
+                    name = string.Format("{0} {1}", Properties.Resources.PropName_Iteration, iterationReport.Index);
+                }
+
+                // concat hierarchy name
+                hierarchyName = name + split + hierarchyName;
+
+                parentReport = parentReport.Owner as GeneralReportNode;
+            }
+
+            return hierarchyName;
+        }
+        #endregion
+
+        #region For API test only
+        // For API test only
+        private static testsuitesTestsuite TryConvertTestsuite(XmlReport.APITest.TestReport testReport, int index)
+        {
+            if (testReport == null)
+            {
+                return null;
+            }
+
+            testsuitesTestsuite ts = new testsuitesTestsuite();
+            FillTestsuiteCommonData(ts, testReport, index);
+
+            // JUnit testcases
+            int testcaseCount = 0;
+            int failureCount = 0;
+            ts.testcase = ConvertTestcases(testReport.Iterations, out testcaseCount, out failureCount);
+            ts.tests = testcaseCount;
+            ts.failures = failureCount;
+
+            return ts;
+        }
+
+        // For API test only
+        private static testsuiteTestcase[] ConvertTestcases(ReportNodeCollection<XmlReport.APITest.IterationReport> iterationReports, out int count, out int numOfFailures)
+        {
+            count = 0;
+            numOfFailures = 0;
+
+            List<testsuiteTestcase> list = new List<testsuiteTestcase>();
+            if (iterationReports != null)
+            {
+                int iterationNum = 0;
+                foreach (XmlReport.APITest.IterationReport iteration in iterationReports)
+                {
+                    iterationNum++;
+
+                    if (iteration.AllActivitiesEnumerator != null)
+                    {
+                        EnumerableReportNodes<XmlReport.APITest.ActivityReport> activities = new EnumerableReportNodes<XmlReport.APITest.ActivityReport>(iteration.AllActivitiesEnumerator);
+                        foreach (XmlReport.APITest.ActivityReport activity in activities)
+                        {
+                            testsuiteTestcase tc = APITestReportConverter.ConvertTestcase(activity, count);
+                            if (tc == null)
+                            {
+                                continue;
+                            }
+
+                            // update activity name with the hierarchy full name
+                            tc.name = string.Format("#{0,7:0000000}: {1}", count + 1, GetHierarchyFullName(activity, iterationNum));
+
+                            list.Add(tc);
+                            if (activity.Status == ReportStatus.Failed)
+                            {
+                                numOfFailures++;
+                            }
+                            count++;
+                        }
+                    }
+                }
+            }
+
+            return list.ToArray();
+        }
+
+        // For API test only
+        private static string GetHierarchyFullName(XmlReport.APITest.ActivityReport activityReport, int iterationNum, string split = " / ")
+        {
+            string hierarchyName = activityReport.Name;
+
+            GeneralReportNode parentReport = activityReport.Owner as GeneralReportNode;
+            while (parentReport != null)
+            {
+                string name = parentReport.Name;
+
+                if (parentReport is XmlReport.APITest.IterationReport iterationReport)
+                {
+                    // if it is API iteration, prepend "Iteration" term
+                    name = string.Format("{0} {1}", Properties.Resources.PropName_Iteration, iterationNum);
+                }
+
+                // concat hierarchy name
+                hierarchyName = name + split + hierarchyName;
+
+                parentReport = parentReport.Owner as GeneralReportNode;
+            }
+
+            return hierarchyName;
+        }
+        #endregion
+
+        #region For BPT test only
+        // For BPT test only
+        private static testsuitesTestsuite TryConvertTestsuite(XmlReport.BPT.TestReport testReport, int index)
+        {
+            if (testReport == null)
+            {
+                return null;
+            }
+
+            testsuitesTestsuite ts = new testsuitesTestsuite();
+            FillTestsuiteCommonData(ts, testReport, index);
+
+            // JUnit testcases
+            int testcaseCount = 0;
+            int failureCount = 0;
+            ts.testcase = ConvertTestcases(testReport.AllBCsEnumerator, out testcaseCount, out failureCount);
+            ts.tests = testcaseCount;
+            ts.failures = failureCount;
+
+            return ts;
+        }
+
+        // For BPT test only
+        private static testsuiteTestcase[] ConvertTestcases(ReportNodeEnumerator<XmlReport.BPT.BusinessComponentReport> bcs, out int count, out int numOfFailures)
+        {
+            count = 0;
+            numOfFailures = 0;
+
+            List<testsuiteTestcase> list = new List<testsuiteTestcase>();
+            if (bcs != null)
+            {
+                EnumerableReportNodes<XmlReport.BPT.BusinessComponentReport> bcReports = new EnumerableReportNodes<XmlReport.BPT.BusinessComponentReport>(bcs);
+                foreach (XmlReport.BPT.BusinessComponentReport bc in bcReports)
+                {
+                    if (bc.AllBCStepsEnumerator != null)
+                    {
+                        EnumerableReportNodes<XmlReport.BPT.BCStepReport> steps = new EnumerableReportNodes<XmlReport.BPT.BCStepReport>(bc.AllBCStepsEnumerator);
+                        foreach (XmlReport.BPT.BCStepReport step in steps)
+                        {
+                            if (step.IsContext)
+                            {
+                                continue;
+                            }
+
+                            testsuiteTestcase tc = BPTReportConverter.ConvertTestcase(step, count);
+                            if (tc == null)
+                            {
+                                continue;
+                            }
+
+                            // update step name with the hierarchy full name
+                            tc.name = string.Format("#{0,7:0000000}: {1}", count + 1, GetHierarchyFullName(step, bc));
+
+                            list.Add(tc);
+                            if (step.Status == ReportStatus.Failed)
+                            {
+                                numOfFailures++;
+                            }
+                            count++;
+                        }
+                    }
+
+
+                }
+            }
+
+            return list.ToArray();
+        }
+
+        // For BPT test only
+        private static string GetHierarchyFullName(XmlReport.BPT.BCStepReport stepReport, XmlReport.BPT.BusinessComponentReport bc, string split = " / ")
+        {
+            return BPTReportConverter.GetBCHierarchyName(bc) + split + stepReport.Name;
+        }
+        #endregion
+
+        // For GUI / API / BPT tests
+        private static void FillTestsuiteCommonData(testsuitesTestsuite ts, TestReportBase testReport, int index)
+        {
+            ts.id = index; // Starts at '0' for the first testsuite and is incremented by 1 for each following testsuite
+            ts.package = testReport.TestAndReportName;
+            ts.name = string.Format("TEST-{0,3:000}: {1}", index + 1, testReport.TestAndReportName);
+
+            // other JUnit required fields
+            ts.timestamp = testReport.TestRunStartTime;
+            ts.hostname = testReport.HostName;
+            if (string.IsNullOrWhiteSpace(ts.hostname)) ts.hostname = "localhost";
+            ts.time = testReport.TestDurationSeconds;
+
+            // properties
+            List<testsuiteProperty> properties = new List<testsuiteProperty>(ConvertTestsuiteCommonProperties(testReport));
+            ts.properties = properties.ToArray();
+        }
+
+        // For GUI / API / BPT tests
+        private static IEnumerable<testsuiteProperty> ConvertTestsuiteCommonProperties(TestReportBase testReport)
+        {
+            yield return new testsuiteProperty(Properties.Resources.PropName_TestingTool, testReport.TestingToolNameVersion);
+            yield return new testsuiteProperty(Properties.Resources.PropName_OSInfo, testReport.OSInfo);
+            yield return new testsuiteProperty(Properties.Resources.PropName_Locale, testReport.Locale);
+            yield return new testsuiteProperty(Properties.Resources.PropName_LoginUser, testReport.LoginUser);
+            yield return new testsuiteProperty(Properties.Resources.PropName_CPUInfo, testReport.CPUInfoAndCores);
+            yield return new testsuiteProperty(Properties.Resources.PropName_Memory, testReport.TotalMemory);
+
+            if (testReport.TestInputParameters != null)
+            {
+                foreach (ParameterType pt in testReport.TestInputParameters)
+                {
+                    // sample of property name:
+                    //   Test input: param1 (System.String)
+                    yield return new testsuiteProperty(Properties.Resources.PropName_Prefix_TestInputParam + pt.NameAndType, pt.value);
+                }
+            }
+
+            if (testReport.TestOutputParameters != null)
+            {
+                foreach (ParameterType pt in testReport.TestOutputParameters)
+                {
+                    // sample of property name:
+                    //   Test output: param1 (System.String)
+                    yield return new testsuiteProperty(Properties.Resources.PropName_Prefix_TestOutputParam + pt.NameAndType, pt.value);
+                }
+            }
+
+            if (testReport.TestAUTs != null)
+            {
+                int i = 0;
+                foreach (TestedApplicationType aut in testReport.TestAUTs)
+                {
+                    i++;
+                    string propValue = aut.Name;
+                    if (!string.IsNullOrWhiteSpace(aut.Version))
+                    {
+                        propValue += string.Format(" {0}", aut.Version);
+                    }
+                    if (!string.IsNullOrWhiteSpace(aut.Path))
+                    {
+                        propValue += string.Format(" ({0})", aut.Path);
+                    }
+                    yield return new testsuiteProperty(string.Format("{0} {1}", Properties.Resources.PropName_Prefix_AUT, i), propValue);
+                }
+            }
+        }
+
+    }
+}

--- a/ReportConverter/JUnit/BPTReportConverter.cs
+++ b/ReportConverter/JUnit/BPTReportConverter.cs
@@ -8,6 +8,11 @@ using System.Threading.Tasks;
 
 namespace ReportConverter.JUnit
 {
+    /// <summary>
+    /// Junit-testsuites <==> BPT
+    /// Junit-testsuite <==> Business Component (BC)
+    /// Junit-testcase <==> GUI Step / API Activity
+    /// </summary>
     class BPTReportConverter : ConverterBase
     {
         public BPTReportConverter(CommandArguments args, TestReport input) : base(args)
@@ -80,7 +85,7 @@ namespace ReportConverter.JUnit
             return ts;
         }
 
-        private string GetBCHierarchyName(BusinessComponentReport bcReport, string split = " / ")
+        public static string GetBCHierarchyName(BusinessComponentReport bcReport, string split = " / ")
         {
             string hierarchyName = bcReport.Name;
 
@@ -125,7 +130,7 @@ namespace ReportConverter.JUnit
             };
         }
 
-        private IEnumerable<testsuiteProperty> ConvertTestsuiteProperties(BusinessComponentReport bcReport)
+        private static IEnumerable<testsuiteProperty> ConvertTestsuiteProperties(BusinessComponentReport bcReport)
         {
             List<testsuiteProperty> list = new List<testsuiteProperty>();
 
@@ -162,7 +167,7 @@ namespace ReportConverter.JUnit
             return list;
         }
 
-        private testsuiteTestcase[] ConvertTestcases(BusinessComponentReport bcReport, out int count, out int numOfFailures)
+        public static testsuiteTestcase[] ConvertTestcases(BusinessComponentReport bcReport, out int count, out int numOfFailures)
         {
             count = 0;
             numOfFailures = 0;
@@ -193,7 +198,7 @@ namespace ReportConverter.JUnit
         /// <param name="stepReport">The <see cref="BCStepReport"/> instance contains the data of a BPT business component step.</param>
         /// <param name="index">The index, starts from 0, to identify the order of the testcases.</param>
         /// <returns>The converted JUnit <see cref="testsuiteTestcase"/> instance.</returns>
-        private testsuiteTestcase ConvertTestcase(BCStepReport stepReport, int index)
+        public static testsuiteTestcase ConvertTestcase(BCStepReport stepReport, int index)
         {
             testsuiteTestcase tc = new testsuiteTestcase();
             tc.name = string.Format("#{0,5:00000}: {1}", index + 1, stepReport.Name);

--- a/ReportConverter/JUnit/Converter.cs
+++ b/ReportConverter/JUnit/Converter.cs
@@ -52,6 +52,23 @@ namespace ReportConverter.JUnit
 
             return true;
         }
+
+        public static bool ConvertAndSaveAggregation(CommandArguments args, IEnumerable<TestReportBase> input)
+        {
+            AggregativeReportConverter converter = new AggregativeReportConverter(args, input);
+
+            if (!converter.Convert())
+            {
+                return false;
+            }
+
+            if (!converter.SaveFile())
+            {
+                return false;
+            }
+
+            return true;
+        }
     }
 
     abstract class ConverterBase

--- a/ReportConverter/JUnit/GUITestReportConverter.cs
+++ b/ReportConverter/JUnit/GUITestReportConverter.cs
@@ -8,6 +8,11 @@ using System.Threading.Tasks;
 
 namespace ReportConverter.JUnit
 {
+    /// <summary>
+    /// Junit-testsuites <==> GUI test
+    /// Junit-testsuite <==> Action iteration / Action
+    /// Junit-testcase <==> Step
+    /// </summary>
     class GUITestReportConverter : ConverterBase
     {
         public GUITestReportConverter(CommandArguments args, TestReport input) : base(args)
@@ -326,7 +331,7 @@ namespace ReportConverter.JUnit
         /// <param name="stepReport">The <see cref="StepReport"/> instance contains the data of a GUI test step.</param>
         /// <param name="index">The index, starts from 0, to identify the order of the testcases.</param>
         /// <returns>The converted JUnit <see cref="testsuiteTestcase"/> instance.</returns>
-        private static testsuiteTestcase ConvertTestcase(StepReport stepReport, int index)
+        public static testsuiteTestcase ConvertTestcase(StepReport stepReport, int index)
         {
             // the step might be a checkpoint
             CheckpointReport checkpointReport = CheckpointReport.FromStepReport(stepReport);

--- a/ReportConverter/Properties/Resources.Designer.cs
+++ b/ReportConverter/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace ReportConverter.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -97,7 +97,20 @@ namespace ReportConverter.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The path to a directory where the raw XML report can be found..
+        ///   Looks up a localized string similar to Create the target report file with the aggregation of multiple
+        ///    raw XML reports..
+        /// </summary>
+        internal static string ArgDesc_AggregationOption {
+            get {
+                return ResourceManager.GetString("ArgDesc_AggregationOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The path to a directory where the raw XML report can be found.
+        ///
+        ///  If the &quot;aggregation&quot; option is enabled, the program accepts multiple
+        ///  paths to the directories..
         /// </summary>
         internal static string ArgDesc_InputFile {
             get {
@@ -550,6 +563,15 @@ namespace ReportConverter.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sample {0}:.
+        /// </summary>
+        internal static string Prog_Usage_SampleTitle {
+            get {
+                return ResourceManager.GetString("Prog_Usage_SampleTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to MB.
         /// </summary>
         internal static string Prop_MemoryUnit {
@@ -762,6 +784,24 @@ namespace ReportConverter.Properties {
         internal static string PropName_Prefix_IterationOutputParam {
             get {
                 return ResourceManager.GetString("PropName_Prefix_IterationOutputParam", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test input: .
+        /// </summary>
+        internal static string PropName_Prefix_TestInputParam {
+            get {
+                return ResourceManager.GetString("PropName_Prefix_TestInputParam", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test output: .
+        /// </summary>
+        internal static string PropName_Prefix_TestOutputParam {
+            get {
+                return ResourceManager.GetString("PropName_Prefix_TestOutputParam", resourceCulture);
             }
         }
         

--- a/ReportConverter/Properties/Resources.resx
+++ b/ReportConverter/Properties/Resources.resx
@@ -351,7 +351,10 @@ Please run test with "HTML Report" format to generate the XML report file.</valu
     <value>Recovery</value>
   </data>
   <data name="ArgDesc_InputFile" xml:space="preserve">
-    <value>The path to a directory where the raw XML report can be found.</value>
+    <value>The path to a directory where the raw XML report can be found.
+
+  If the "aggregation" option is enabled, the program accepts multiple
+  paths to the directories.</value>
   </data>
   <data name="ArgDesc_JUnitFileOption" xml:space="preserve">
     <value>Convert the raw XML report to JUnit report XML format and
@@ -383,5 +386,19 @@ Please run test with "HTML Report" format to generate the XML report file.</valu
   </data>
   <data name="Test_Step" xml:space="preserve">
     <value>Step</value>
+  </data>
+  <data name="PropName_Prefix_TestInputParam" xml:space="preserve">
+    <value>Test input: </value>
+  </data>
+  <data name="PropName_Prefix_TestOutputParam" xml:space="preserve">
+    <value>Test output: </value>
+  </data>
+  <data name="ArgDesc_AggregationOption" xml:space="preserve">
+    <value>Create the target report file with the aggregation of multiple
+    raw XML reports.</value>
+  </data>
+  <data name="Prog_Usage_SampleTitle" xml:space="preserve">
+    <value>Sample {0}:</value>
+    <comment>{0} is the number of the sample</comment>
   </data>
 </root>

--- a/ReportConverter/ReportConverter.csproj
+++ b/ReportConverter/ReportConverter.csproj
@@ -9,8 +9,8 @@
     <Copyright>© Copyright 1992-2021 Micro Focus or one of its affiliates.</Copyright>
     <Description>A command-line tool that converts UFT report to other formats.</Description>
     <RepositoryUrl>https://github.com/MicroFocus/ADM-FT-ToolsLauncher</RepositoryUrl>
-    <AssemblyVersion>1.0.17.211</AssemblyVersion>
-    <FileVersion>1.0.17.211</FileVersion>
+    <AssemblyVersion>1.0.19.501</AssemblyVersion>
+    <FileVersion>1.0.19.501</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net5.0|AnyCPU'">


### PR DESCRIPTION
In this change, the `--aggregation` optional argument is introduced to convert multiple reports into one Junit Xml file.
The command line to do so is like: `ReportConverter -j junit.xml --aggregation "report1" "report2" "report3"`.

The aggregative Junit Xml report has the following mappings between the UFT report nodes and Junit elements:
| Junit element | UFT report node type
| ---- | ---- |
| testsuites | Aggregative report |
| testsuite | GUITest / APITest / BPT |
| testcase | Step (for GUITest)<br/>Activity (for APITest)<br/>Step / Activity (for BPT) |

The testcase name in the Junit Xml report is rebuilt to involve all the ancestor node types to distinguish among all other testcases:
| Test type | Junit `testcase` name pattern |
| ---- | ---- |
| GUITest | `Iteration X / Action N / Step M`<br/>`Iteration X / Action N / Action Iteration Y / Step M` |
| APITest | `Iteration X / Activity N` |
| BPT | `... / Business Component X / Step N` |