### PR TITLE
Fix the relative report path issue

### DIFF
--- a/HpToolsLauncher/Properties/AssemblyInfo.cs
+++ b/HpToolsLauncher/Properties/AssemblyInfo.cs
@@ -54,6 +54,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.24.2034")]
+[assembly: AssemblyVersion("1.0.25.132")]
 //[assembly: AssemblyFileVersion("1.0")]
 [assembly: AssemblyInformationalVersion("1.0-beta")]

--- a/HpToolsLauncher/TestRunners/GuiTestRunner.cs
+++ b/HpToolsLauncher/TestRunners/GuiTestRunner.cs
@@ -101,11 +101,12 @@ namespace HpToolsLauncher
             // check if the report path has been defined
             if (!string.IsNullOrWhiteSpace(testinf.ReportPath))
             {
-                runDesc.ReportLocation = testinf.ReportPath;
+                runDesc.ReportLocation = Path.GetFullPath(testinf.ReportPath);
                 ConsoleWriter.WriteLine(DateTime.Now.ToString(Launcher.DateFormat) + " Report path is set explicitly: " + runDesc.ReportLocation);
             }
             else if (!String.IsNullOrEmpty(testinf.ReportBaseDirectory))
             {
+                testinf.ReportBaseDirectory = Path.GetFullPath(testinf.ReportBaseDirectory);
                 if (!Helper.TrySetTestReportPath(runDesc, testinf, ref errorReason))
                 {
                     return runDesc;
@@ -116,7 +117,7 @@ namespace HpToolsLauncher
             {
                 // default report location is the next available folder under test path
                 // for example, "path\to\tests\GUITest1\Report123", the name "Report123" will also be used as the report name
-                string reportBasePath = testPath;
+                string reportBasePath = Path.GetFullPath(testPath);
                 string testReportPath = Path.Combine(reportBasePath, "Report" + DateTime.Now.ToString("ddMMyyyyHHmmssfff"));
                 int index = 0;
                 while (index < int.MaxValue)


### PR DESCRIPTION
Fix the issue that when specifying the report path with a **relative path**, the report path is not generated. The affected parameters are `fsReportPath` and `fsReportPath{i}`.